### PR TITLE
In scripts replaced sh with bash

### DIFF
--- a/indexr-server/src/main/java/io/indexr/tool/Tools.java
+++ b/indexr-server/src/main/java/io/indexr/tool/Tools.java
@@ -206,7 +206,7 @@ public class Tools {
 
     private static boolean setTable(MyOptions options, IndexRConfig config) throws Exception {
         Preconditions.checkState(!Strings.isEmpty(options.table), "Please specify table name! -t <name>");
-        Preconditions.checkState(!Strings.isEmpty(options.schemapath), "Please specify scheam path! -c <path>");
+        Preconditions.checkState(!Strings.isEmpty(options.schemapath), "Please specify schema path! -c <path>");
         String[] tableNames = options.table.split(",");
         Preconditions.checkState(tableNames.length == 1, "Can only add one table one time!");
         TableSchema schema = JsonUtil.loadConfig(Paths.get(options.schemapath), TableSchema.class);

--- a/indexr-tool/bin/csv_exporter.sh
+++ b/indexr-tool/bin/csv_exporter.sh
@@ -1,4 +1,4 @@
 ROOT_DIR=$(cd $(dirname $0);echo $PWD)
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib
 
-sh ${ROOT_DIR}/run_class.sh io.indexr.tool.CSVSegmentExporter "$@"
+bash ${ROOT_DIR}/run_class.sh io.indexr.tool.CSVSegmentExporter "$@"

--- a/indexr-tool/bin/csv_loader.sh
+++ b/indexr-tool/bin/csv_loader.sh
@@ -1,4 +1,4 @@
 ROOT_DIR=$(cd $(dirname $0);echo $PWD)
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib
 
-sh ${ROOT_DIR}/run_class.sh io.indexr.tool.CSVSegmentLoader "$@"
+bash ${ROOT_DIR}/run_class.sh io.indexr.tool.CSVSegmentLoader "$@"

--- a/indexr-tool/bin/rt2his.sh
+++ b/indexr-tool/bin/rt2his.sh
@@ -1,4 +1,4 @@
 ROOT_DIR=$(cd $(dirname $0);echo $PWD)
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib
 
-sh ${ROOT_DIR}/run_class.sh io.indexr.tool.Rt2His "$@"
+bash ${ROOT_DIR}/run_class.sh io.indexr.tool.Rt2His "$@"

--- a/indexr-tool/bin/tools.sh
+++ b/indexr-tool/bin/tools.sh
@@ -1,3 +1,3 @@
 ROOT_DIR=$(cd $(dirname $0);echo $PWD)
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib
-sh ${ROOT_DIR}/run_class.sh io.indexr.tool.Tools "$@"
+bash ${ROOT_DIR}/run_class.sh io.indexr.tool.Tools "$@"

--- a/script/release_all.sh
+++ b/script/release_all.sh
@@ -8,8 +8,8 @@ ROOT_DIR=$(echo $PWD)
 rm -rf ${ROOT_DIR}/indexr-query-opt/src/main/java/io/indexr/query/parsers
 rm -rf ${ROOT_DIR}/indexr-query-opt/src/main/java/*.tokens
 
-sh ${ROOT_DIR}/script/release_indexr-drill.sh
-sh ${ROOT_DIR}/script/release_indexr-hive.sh
-sh ${ROOT_DIR}/script/release_indexr-spark.sh
-sh ${ROOT_DIR}/script/release_indexr-tool.sh
-sh ${ROOT_DIR}/script/release_lib.sh
+bash ${ROOT_DIR}/script/release_indexr-drill.sh
+bash ${ROOT_DIR}/script/release_indexr-hive.sh
+bash ${ROOT_DIR}/script/release_indexr-spark.sh
+bash ${ROOT_DIR}/script/release_indexr-tool.sh
+bash ${ROOT_DIR}/script/release_lib.sh

--- a/script/release_indexr-drill.sh
+++ b/script/release_indexr-drill.sh
@@ -10,7 +10,7 @@ cd ${ROOT_DIR}
 
 rm -rf ${RELEASE_PATH}/indexr-drill
 mkdir -p ${RELEASE_PATH}/indexr-drill/jars/3rdparty
-sh ${ROOT_DIR}/script/compile_indexr-server.sh
+bash ${ROOT_DIR}/script/compile_indexr-server.sh
 
 function cp_jar {
     if [ ! -f $1 ]; then

--- a/script/release_indexr-hive.sh
+++ b/script/release_indexr-hive.sh
@@ -8,7 +8,7 @@ RELEASE_PATH=${ROOT_DIR}/distribution/indexr-${VERSION}
 
 cd ${ROOT_DIR}
 
-sh ${ROOT_DIR}/script/compile_indexr-hive.sh
+bash ${ROOT_DIR}/script/compile_indexr-hive.sh
 
 # copy hive files
 rm -rf ${RELEASE_PATH}/indexr-hive/aux

--- a/script/release_indexr-spark.sh
+++ b/script/release_indexr-spark.sh
@@ -8,7 +8,7 @@ RELEASE_PATH=${ROOT_DIR}/distribution/indexr-${VERSION}
 
 cd ${ROOT_DIR}
 
-sh ${ROOT_DIR}/script/compile_indexr-spark.sh
+bash ${ROOT_DIR}/script/compile_indexr-spark.sh
 
 rm -rf ${RELEASE_PATH}/indexr-spark/jars
 mkdir -p ${RELEASE_PATH}/indexr-spark/jars

--- a/script/setup_all.sh
+++ b/script/setup_all.sh
@@ -3,5 +3,5 @@ SCRIPT_DIR=$(cd $(dirname $0);echo $PWD)
 cd ${SCRIPT_DIR}/..
 ROOT_DIR=$(echo $PWD)
 
-sh ${ROOT_DIR}/script/setup_indexr-segment.sh
-sh ${ROOT_DIR}/script/setup_lib.sh
+bash ${ROOT_DIR}/script/setup_indexr-segment.sh
+bash ${ROOT_DIR}/script/setup_lib.sh


### PR DESCRIPTION
Running `setup_all` and `release_all` scripts on ubuntu 16.04 throws error `source not found` as any other script (e.g. `setup_indexr-segment.sh`, `setup_lib.sh`) is invoked via `sh` instead of `bash`. Replacing `sh` with `bash` is fine as all the scripts contain shebang (`#!/usr/bin/env bash`) which requires `bash` so no point in using `sh`.